### PR TITLE
Migrating to mongo-java-driver 3.0.0.rc1

### DIFF
--- a/lambdamatic-mongodb/lambdamatic-mongodb-core-tests/src/test/java/org/lambdamatic/mongodb/internal/codecs/DocumentCodecTest.java
+++ b/lambdamatic-mongodb/lambdamatic-mongodb-core-tests/src/test/java/org/lambdamatic/mongodb/internal/codecs/DocumentCodecTest.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -22,7 +21,8 @@ import org.bson.codecs.BsonValueCodecProvider;
 import org.bson.codecs.DecoderContext;
 import org.bson.codecs.EncoderContext;
 import org.bson.codecs.ValueCodecProvider;
-import org.bson.codecs.configuration.RootCodecRegistry;
+import org.bson.codecs.configuration.CodecRegistries;
+import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.json.JsonReader;
 import org.bson.json.JsonWriter;
 import org.bson.types.ObjectId;
@@ -34,9 +34,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
-import org.lambdamatic.mongodb.internal.codecs.BindingService;
-import org.lambdamatic.mongodb.internal.codecs.DocumentCodec;
-import org.lambdamatic.mongodb.internal.codecs.FilterExpressionCodec;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,9 +56,10 @@ import com.sample.Foo.FooBuilder;
 @RunWith(Parameterized.class)
 public class DocumentCodecTest {
 
-	private static final RootCodecRegistry DEFAULT_CODEC_REGISTRY = new RootCodecRegistry(Arrays.asList(
+	private static final CodecRegistry DEFAULT_CODEC_REGISTRY = CodecRegistries.fromProviders(
 			new ValueCodecProvider(), new DBRefCodecProvider(), new DBObjectCodecProvider(),
-			new BsonValueCodecProvider()));
+			new BsonValueCodecProvider());
+	
 	/** The usual Logger. */
 	private static final Logger LOGGER = LoggerFactory.getLogger(DocumentCodecTest.class);
 

--- a/lambdamatic-mongodb/lambdamatic-mongodb-core-tests/src/test/java/org/lambdamatic/mongodb/testutils/DropMongoCollectionsRule.java
+++ b/lambdamatic-mongodb/lambdamatic-mongodb-core-tests/src/test/java/org/lambdamatic/mongodb/testutils/DropMongoCollectionsRule.java
@@ -32,7 +32,7 @@ public class DropMongoCollectionsRule implements MethodRule {
 			@Override
 			public void evaluate() throws Throwable {
 				// clean the collection
-				collection.dropCollection();
+				collection.drop();
 				base.evaluate();
 			}
 		};

--- a/lambdamatic-mongodb/lambdamatic-mongodb-core/src/main/java/org/lambdamatic/mongodb/internal/FindContextImpl.java
+++ b/lambdamatic-mongodb/lambdamatic-mongodb-core/src/main/java/org/lambdamatic/mongodb/internal/FindContextImpl.java
@@ -6,6 +6,10 @@ package org.lambdamatic.mongodb.internal;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.bson.BsonDocument;
+import org.bson.BsonDocumentWrapper;
+import org.bson.codecs.Codec;
+import org.bson.codecs.configuration.CodecRegistry;
 import org.lambdamatic.SerializableFunction;
 import org.lambdamatic.mongodb.metadata.Projection;
 import org.lambdamatic.mongodb.query.context.FindContext;
@@ -24,17 +28,23 @@ public class FindContextImpl<T, PM> implements FindContext<T, PM> {
 	/** the underlying Mongo {@link FindFluent}.*/ 
 	private final FindIterable<T> find;
 	
+	/** The registry of the custom {@link Codec}.*/
+	private final CodecRegistry codecRegistry;
+	
 	/**
 	 * Constructor
-	 * @param find the {@link FindFluent} element built with a Filter argument.
+	 * @param find The {@link FindFluent} element built with a Filter argument.
+	 * @param codecRegistry The registry of the custom {@link Codec}.
 	 */
-	public FindContextImpl(final FindIterable<T> find) {
+	public FindContextImpl(final FindIterable<T> find, final CodecRegistry codecRegistry) {
 		this.find = find;
+		this.codecRegistry = codecRegistry;
 	}
 
 	@Override
 	public FindTerminalContext<T> projection(final SerializableFunction<PM, Projection> projectionExpression) {
-		find.projection(projectionExpression);
+		final BsonDocument projectionDocument = BsonDocumentWrapper.asBsonDocument(projectionExpression, codecRegistry);
+		find.projection(projectionDocument);
 		return this;
 	}
 	

--- a/lambdamatic-mongodb/lambdamatic-mongodb-core/src/main/java/org/lambdamatic/mongodb/internal/connexion/MongoClientProducer.java
+++ b/lambdamatic-mongodb/lambdamatic-mongodb-core/src/main/java/org/lambdamatic/mongodb/internal/connexion/MongoClientProducer.java
@@ -18,6 +18,7 @@ import javax.inject.Singleton;
 import org.lambdamatic.mongodb.internal.configuration.MongoClientConfiguration;
 
 import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
 
 /**
  * CDI Producer for a single {@link MongoClient} instance.

--- a/lambdamatic-mongodb/pom.xml
+++ b/lambdamatic-mongodb/pom.xml
@@ -13,7 +13,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<mongodb.driver.version>3.0.0-beta2</mongodb.driver.version>
+		<mongodb.driver.version>3.0.0-rc1</mongodb.driver.version>
 		<jackson.version>2.4.0</jackson.version>
 		<bson4jackson.version>2.4.0</bson4jackson.version>
 		<stringtemplate.version>4.0.2</stringtemplate.version>


### PR DESCRIPTION
There was an impact on the API, with changes on the CodecRegistry
and the need to convert the document into a Bson object using the
BsonDocumentWrapper.asBsonDocument(Object, CodeRegistry)
