### PR TITLE
(infra) Switch to container-based jobs on Travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+sudo: false
+cache:
+  directories:
+  - $HOME/.m2
+  
 language: java
 jdk:
   - oraclejdk8


### PR DESCRIPTION
Using cache for .m2 to avoid subsequent dependency downloads
See http://docs.travis-ci.com/user/caching/
