### PR TITLE
(fix) Fix bugs discovered with JDK version 1.8.0_60

### DIFF
--- a/lambdamatic-analyzer/src/main/java/org/lambdamatic/analyzer/LambdaExpressionAnalyzer.java
+++ b/lambdamatic-analyzer/src/main/java/org/lambdamatic/analyzer/LambdaExpressionAnalyzer.java
@@ -227,7 +227,8 @@ public class LambdaExpressionAnalyzer {
 		final List<Statement> lambdaExpressionStatements = bytecode.getLeft();
 		final List<Statement> processedBlock = lambdaExpressionStatements.stream().map(s -> thinOut(s))
 				.map(s -> simplify(s)).collect(Collectors.toList());
-		final LocalVariable lambdaExpressionArgument = lambdaExpressionArguments.get(0);
+		// first argument that is not a captured argument.
+		final LocalVariable lambdaExpressionArgument = lambdaExpressionArguments.get(lambdaInfo.getCapturedArguments().size());
 		return new LambdaExpression(processedBlock, lambdaExpressionArgument.getJavaType(),
 				lambdaExpressionArgument.getName());
 	}

--- a/lambdamatic-analyzer/src/test/java/org/lambdamatic/analyzer/IsolatedLambdaBytecodeAnalyzerTest.java
+++ b/lambdamatic-analyzer/src/test/java/org/lambdamatic/analyzer/IsolatedLambdaBytecodeAnalyzerTest.java
@@ -1,22 +1,23 @@
 package org.lambdamatic.analyzer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.lambdamatic.testutils.JavaMethods.Object_equals;
+import static org.lambdamatic.testutils.JavaMethods.TestPojo_elementMatch;
 
 import java.io.IOException;
 
 import org.junit.Test;
 import org.lambdamatic.SerializableConsumer;
-import org.lambdamatic.analyzer.ast.node.Assignment;
+import org.lambdamatic.analyzer.ast.node.Expression;
 import org.lambdamatic.analyzer.ast.node.ExpressionStatement;
 import org.lambdamatic.analyzer.ast.node.FieldAccess;
 import org.lambdamatic.analyzer.ast.node.LambdaExpression;
 import org.lambdamatic.analyzer.ast.node.LocalVariable;
-import org.lambdamatic.analyzer.ast.node.NumberLiteral;
-import org.lambdamatic.analyzer.ast.node.Operation;
-import org.lambdamatic.analyzer.ast.node.Operation.Operator;
+import org.lambdamatic.analyzer.ast.node.MethodInvocation;
+import org.lambdamatic.analyzer.ast.node.ReturnStatement;
 import org.lambdamatic.analyzer.ast.node.StringLiteral;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.slf4j.LoggerFactory; 
 
 import com.sample.model.TestPojo;
 
@@ -35,23 +36,21 @@ public class IsolatedLambdaBytecodeAnalyzerTest {
 	@Test
 	public void shouldParseExpression() throws IOException, NoSuchMethodException, SecurityException {
 		// given
-		final SerializableConsumer<TestPojo> expression = (SerializableConsumer<TestPojo>) ((
-				TestPojo t) -> {t.stringValue = "foo"; t.field = "bar"; t.primitiveIntValue++;});
+		final TestPojo anotherPojo = new TestPojo();
+		final SerializableConsumer<TestPojo> expression = (SerializableConsumer<TestPojo>) (t -> t.elementMatch(e -> e.field.equals(anotherPojo.getStringValue())));
 		// when
 		final LambdaExpression resultExpression = analyzer.analyzeExpression(expression);
 		// then
-		final LocalVariable t = new LocalVariable(1, "t", TestPojo.class);
-		final FieldAccess t_dot_stringValue = new FieldAccess(t, "stringValue");
-		final ExpressionStatement set_t_dot_stringValue = new ExpressionStatement(new Assignment(t_dot_stringValue, new StringLiteral("foo")));
-		final FieldAccess t_dot_field = new FieldAccess(t, "field");
-		final ExpressionStatement set_t_dot_field = new ExpressionStatement(new Assignment(t_dot_field, new StringLiteral("bar")));
-		final FieldAccess t_dot_primitiveIntValue = new FieldAccess(t, "primitiveIntValue");
-		final ExpressionStatement inc_primitiveInt = new ExpressionStatement(new Assignment(t_dot_primitiveIntValue, new Operation(Operator.ADD, t_dot_primitiveIntValue, new NumberLiteral(1))));
+		final LocalVariable testPojo = new LocalVariable(0, "t", TestPojo.class);
+		final FieldAccess e_dot_field = new FieldAccess(new LocalVariable(0, "e", TestPojo.class), "field");
+		final LambdaExpression e_dot_field_equals_foo = new LambdaExpression(
+				new ReturnStatement(new MethodInvocation(e_dot_field, Object_equals, new StringLiteral("foo"))),
+				TestPojo.class, "e");
+		
+		final Expression expected = new MethodInvocation(testPojo, TestPojo_elementMatch, e_dot_field_equals_foo);
 		// verification
 		LOGGER.info("Result: {}", resultExpression);
-		assertThat(resultExpression.getArgumentName()).isEqualTo("t");
-		assertThat(resultExpression.getArgumentType()).isEqualTo(TestPojo.class);
-		assertThat(resultExpression.getBody()).containsExactly(set_t_dot_stringValue, set_t_dot_field, inc_primitiveInt);
+		assertThat(resultExpression.getBody()).containsExactly(new ExpressionStatement(expected));
 	}
 }
 

--- a/lambdamatic-analyzer/src/test/java/org/lambdamatic/analyzer/SerializableConsumerExpressionBytecodeAnalyzerTest.java
+++ b/lambdamatic-analyzer/src/test/java/org/lambdamatic/analyzer/SerializableConsumerExpressionBytecodeAnalyzerTest.java
@@ -210,7 +210,6 @@ public class SerializableConsumerExpressionBytecodeAnalyzerTest {
 			}
 			assertThat(resultExpression.getBody()).containsExactly(expectationStatements.toArray(new Statement[0]));
 		}
-
 	}
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 			<dependency>
 				<groupId>org.ow2.asm</groupId>
 				<artifactId>asm-all</artifactId>
-				<version>5.0.1</version>
+				<version>5.0.4</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-io</groupId>


### PR DESCRIPTION
- lambda argument fixed (offset for captured arguments was ignored)
- primitive type supported in local variables in the Lambda Expression
  body
